### PR TITLE
add texpose cvpr 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For an overview of **NeRFs**, checkout the Survey ([Neural Volume Rendering: NeR
 
 * "Shape, Pose, and Appearance from a Single Image via Bootstrapped Radiance Field Inversion", *arXiv*. [[Paper](https://arxiv.org/pdf/2211.11674.pdf)] [[Code](https://github.com/google-research/nerf-from-image)]
 
-* **TexPose**: "Neural Texture Learning for Self-Supervised 6D Object Pose Estimation", *arXiv*. [[Paper](https://arxiv.org/pdf/2212.12902.pdf)]
+* **TexPose**: "Neural Texture Learning for Self-Supervised 6D Object Pose Estimation", *CVPR 2023*. [[Paper](https://arxiv.org/pdf/2212.12902.pdf)]][[Code](https://github.com/HanzhiC/TexPose)]
 
 * **Canonical Fields**: "Self-Supervised Learning of Pose-Canonicalized Neural Fields", *arXiv*. [[Paper](https://arxiv.org/pdf/2212.02493.pdf)]
 


### PR DESCRIPTION
thanks for posting our paper. (TexPose: Neural Texture Learning for Self-Supervised 6D Object Pose Estimation) 
Just updated the code link and the conference